### PR TITLE
Feat: updated the src/basic-samples/ConfirmedPublish.js sample to handle sending many messages without failing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 .DS_Store
 docs/_site
 .idea
+node_modules/

--- a/src/basic-samples/ConfirmedPublish.js
+++ b/src/basic-samples/ConfirmedPublish.js
@@ -128,8 +128,8 @@ var QueueProducer = function (solaceModule, queueName) {
         }
     };
 
-    // Create a message
-    producer.getMessage = function (sequenceNr) {
+    // Builds a message
+    producer.buildMessage = function (sequenceNr) {
         var messageText = 'Sample Message';
         var message = solace.SolclientFactory.createMessage();
         message.setDestination(solace.SolclientFactory.createDurableQueueDestination(producer.queueName));
@@ -153,7 +153,7 @@ var QueueProducer = function (solaceModule, queueName) {
                     producer.log(`Starting send at: ${sentCount}`);
                     while (sentCount < producer.numOfMessages) {
                         var sequenceNr = sentCount + 1;
-                        var message = producer.getMessage(sequenceNr);
+                        var message = producer.buildMessage(sequenceNr);
                         producer.session.send(message);
                         producer.log('Message #' + sequenceNr + ' sent to queue "' + producer.queueName + '", correlation key = ' + JSON.stringify(message.getCorrelationKey()));
                         ++sentCount;
@@ -172,9 +172,10 @@ var QueueProducer = function (solaceModule, queueName) {
         }
     }
 
-    // Sends one message
+    // Sends one message - this function is currently not being used anywhere in this example
+    // only keeping it here for reference as an example to send a single message
     producer.sendMessage = function (sequenceNr) {
-        var message = producer.getMessage(sequenceNr);
+        var message = producer.buildMessage(sequenceNr);
         try {
             producer.session.send(message);
             producer.log('Message #' + sequenceNr + ' sent to queue "' + producer.queueName + '", correlation key = ' + JSON.stringify(message.getCorrelationKey()));


### PR DESCRIPTION
Updated the src/basic-samples/ConfirmedPublish.js sample to send many messages without failing when we hit a **"OperationError: Guaranteed Message Window Closed"** exception. This is response to this community post here - https://solace.community/discussion/3295/sending-large-amount-of-guaranteed-messages-with-nodejs

**Changes:**
- feat: updated the `src/basic-samples/ConfirmedPublish.js` sample to handle sending many messages without failing